### PR TITLE
Update org.freedesktop.Platform runtime to 23.08

### DIFF
--- a/com.emqx.MQTTX.yaml
+++ b/com.emqx.MQTTX.yaml
@@ -1,11 +1,11 @@
 app-id: com.emqx.MQTTX
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '21.08'
+base-version: '23.08'
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node14
+  - org.freedesktop.Sdk.Extension.node18
 separate-locales: false
 command: mqttx.sh
 finish-args:


### PR DESCRIPTION
Updates the Platform and related runtime packages and resolves https://github.com/flathub/com.emqx.MQTTX/issues/19

`org.freedesktop.Platform 21.08 is no longer receiving fixes and security updates.`
