### PR TITLE
Allow usage of wayland

### DIFF
--- a/com.emqx.MQTTX.yaml
+++ b/com.emqx.MQTTX.yaml
@@ -8,7 +8,8 @@ separate-locales: false
 command: mqttx.sh
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   - --device=dri


### PR DESCRIPTION
Otherwise mqttx tries to start in wayland mode and exits